### PR TITLE
Fix: Codespaces compatibility

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,17 +4,10 @@ services:
     volumes:
       - type: volume
         source: vscode-extensions
-        target: /root/.vscode-server/extensions
+        target: /home/python/.vscode-server/extensions
       - type: volume
         source: vscode-extensions-insiders
-        target: /root/.vscode-server-insiders/extensions
-      - type: bind
-        source: ~/.config/gh
-        target: /home/econ/.config/gh
-        read_only: true
-      # - vscode-extensions:/root/.vscode-server/extensions
-      # - vscode-extensions-insiders:/root/.vscode-server-insiders/extensions
-      # - ~/.config/gh:/home/econ/.config/gh:ro
+        target: /home/python/.vscode-server-insiders/extensions
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,8 +2,8 @@ version: "3.9"
 
 services:
   python-repo-template:
-    image: utkusarioglu/python-devcontainer:experiment-feat-python-container-2
+    image: utkusarioglu/python-devcontainer:1.0.6
     volumes:
-      - type: volume
+      - type: bind
         source: ..
         target: /utkusarioglu-com/templates/python-repo-template


### PR DESCRIPTION
- Close #1 by:
  * Fixing repo volume bind type
  * Removing gh config moount. This always causes issues. Instead github
    token shall be provided through an environment variable maybe.
  * Updating the devcontainer version to the latest available.
