### PR TITLE
Chore: Add `GH_TOKEN` env in devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.9"
 services:
   python-repo-template:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
       - type: volume
         source: vscode-extensions


### PR DESCRIPTION
This is done to allow the repo to use gh cli both on local machines
with the `GH_TOKEN` environment variable is defined and on codespaces
where the github config path is not available.
