### PR TITLE
Chore(devcontainer): Ugrade to version 1.0.8

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   python-repo-template:
-    image: utkusarioglu/python-devcontainer:1.0.7
+    image: utkusarioglu/python-devcontainer:1.0.8
     volumes:
       - type: bind
         source: ..


### PR DESCRIPTION
- Add jq to devcontainer. Which is needed by repo-updater for its
  normal operations.
