### PR TITLE
Fix: Main venv not used in shebang

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-#!/opt/bitnami/python/bin/python
+#!/home/python/venv/main/bin/python
 
 def main():
   print("Hey there")


### PR DESCRIPTION
- Close #11 by fixing the shebang line in `src/main.py` to use the main
  venv.
