### PR TITLE
Chore: Alter dev monitoring command chain

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,10 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Dev",
+      "label": "Dev Monitor",
       "detail": "Start src/main.py through watchmedo",
       "type": "shell",
-      "command": "scripts/dev.sh",
+      "command": "scripts/dev-monitor.sh",
       "icon": {
         "color": "terminal.ansiGreen",
         "id": "play"

--- a/scripts/dev-monitor.sh
+++ b/scripts/dev-monitor.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 source ~/venv/main/bin/activate
 
-echo "Starting watchmedo"
+echo "Starting watchmedo…"
 watchmedo shell-command \
   --patterns "*.py" \
+  --recursive \
   --command src/main.py \
   src


### PR DESCRIPTION
- Rename VS Code task for dev monitor as "Dev Monitor"
- Rename script for running dev in monitor mode as
  `scripts/dev-monitor.sh`. This is done to create a distinction between
  a one-off code runner and a runner that reruns the code when it
  detects a change.
