### PR TITLE
Feat: Unit testing tools

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -3,6 +3,8 @@ version: "3.9"
 services:
   python-repo-template:
     image: utkusarioglu/python-devcontainer:1.0.8
+    environment:
+      PYTHONPATH: /utkusarioglu-com/templates/python-repo-template
     volumes:
       - type: bind
         source: ..

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,25 @@
         "clear": false,
         "close": false
       }
+    },
+    {
+      "label": "Test Monitor",
+      "detail": "Run tests",
+      "type": "shell",
+      "command": "scripts/test-monitor.sh",
+      "icon": {
+        "color": "terminal.ansiYellow",
+        "id": "beaker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      }
     }
   ]
 }

--- a/scripts/test-monitor.sh
+++ b/scripts/test-monitor.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Starting watchmedo…"
+watchmedo shell-command \
+  --patterns "*.py" \
+  --recursive \
+  --command "\
+    python -m unittest \
+      discover \
+      -s tests \
+      -p='*_unit_test.py' \
+    " \
+  .
+  

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 #!/home/python/venv/main/bin/python
 
 def main():
-  print("Hey there")
+  return "Hey there"
 
 if __name__ == "__main__":
-  main()
+  print(main())

--- a/tests/main_unit_test.py
+++ b/tests/main_unit_test.py
@@ -1,0 +1,15 @@
+#!/home/python/venv/main/bin/python
+
+import sys
+sys.path.append("..")
+import unittest
+from src import main
+
+class MainTest(unittest.TestCase):
+  def test_main(self):
+    response = main.main()
+    expected = "Hey there"
+    self.assertEqual(expected, response)
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
- Set up unittest as the unit testing library.
- Set up script file `scripts/test-monitor.sh` for monitoring changes in
  src and tests to rerun the tests.
- Add VS Code task for starting test monitor with ease
- Set up `PYTHONPATH` environment variable in `docker-compose.dev.yml`
  to define repo path as a module.
- Create a small unit test file to test the greeting printed by
  `src/main.py`.
- Alter `src/main.py` to be easier to test.
