### PR TITLE
Chore: Devcontainer and testing updates

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   python-repo-template:
-    image: utkusarioglu/python-devcontainer:1.0.12
+    image: utkusarioglu/python-devcontainer:1.0.14
     environment:
       PYTHONPATH: /utkusarioglu-com/templates/python-repo-template
     volumes:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
       "isAsync": true,
       "command": "gh secret set -f .env"
     },
-  ]
+  ],
+  "python.analysis.typeCheckingMode": "basic"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,9 @@
       "detail": "Run tests",
       "type": "shell",
       "command": "scripts/test-monitor.sh",
+      "args": [
+        "${file}"
+      ],
       "icon": {
         "color": "terminal.ansiYellow",
         "id": "beaker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line_length=79

--- a/scripts/test-monitor.sh
+++ b/scripts/test-monitor.sh
@@ -1,14 +1,74 @@
 #!/bin/bash
 
-echo "Starting watchmedo for pytest…"
-watchmedo shell-command \
-  --patterns "*.py" \
-  --recursive \
-  --wait \
-  --verbose \
-  --command '
-      if [ "${watch_event_type}" = "closed" ]; then
-        pytest src/network_delay 
-      fi
-    '\
-  src
+COLOR_RED="\e[31m"
+COLOR_GREEN="\e[32m"
+COLOR_NONE="\e[0m"
+
+PY_EXTENSION="py"
+UNIT_TEST_SUFFIX="unit_test"
+
+file_class="$UNIT_TEST_SUFFIX.$PY_EXTENSION"
+
+function log_error_no_param_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} First param needs to be a valid test or implementation py file path"
+}
+
+function log_error_no_implementation_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} Cannot find the implementation file"
+}
+
+function log_error_no_test_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} Cannot find the test file"
+}
+
+function log_info_starting_watchmedo {
+  echo -e "${COLOR_GREEN}Starting Watchmedo${COLOR_NONE} for '${implementation_basename}'…"
+}
+
+function main {
+  param_abspath=$1
+
+  if [ -z "$param_abspath" ]; then
+    log_error_no_param_abspath
+    exit 1
+  fi
+
+  param_relpath=${param_abspath/$(pwd)\//}
+  param_basename=$(basename $param_relpath)
+  param_filename=${param_basename%.*}
+  param_dir_abspath=${param_abspath/\/$param_basename/}
+
+  implementation_filename="${param_filename/_${UNIT_TEST_SUFFIX}/}"
+  implementation_basename="$implementation_filename.$PY_EXTENSION"
+  implementation_abspath="$param_dir_abspath/$implementation_basename"
+
+  test_filename="${implementation_filename}_$UNIT_TEST_SUFFIX"
+  test_basename="$test_filename.$PY_EXTENSION"
+  test_abspath="$param_dir_abspath/$test_basename"
+
+  if [ ! -f "$implementation_abspath" ]; then
+    log_error_no_implementation_abspath
+    exit 2
+  fi
+
+  if [ ! -f  "$test_abspath" ]; then
+    log_error_no_test_abspath
+    exit 3
+  fi
+
+  log_info_starting_watchmedo
+
+  watchmedo shell-command \
+    --patterns "$test_abspath;$implementation_abspath" \
+    --recursive \
+    --wait \
+    --verbose \
+    --command '
+        if [ "${watch_event_type}" = "closed" ]; then
+          pytest '$test_abspath'
+        fi
+      '\
+    "$param_dir_abspath"
+}
+
+main $@


### PR DESCRIPTION
- Update devcontainer version to `1.0.14`. New version allows the
  ability to use `clear` in the terminal.
- Update `scripts/test-monitor.sh` script to allow targeting certain
  paths for monitoring. This is connected with vscode tasks to allow the
  developer to only target a certain py file and its tests through
  tasks.
- Add `pyproject.toml` to limit the columns to 80 during formatting by
  black. Closes #22.
- Set pyhon type checking mode as "basic" in `.vscode/settings.json`.
